### PR TITLE
fix(6): Promote keycode to dependent

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
-    "keycode": "^2.2.0",
     "mocha": "^5.2.0",
     "parcel-bundler": "^1.9.6",
     "puppeteer": "^1.6.0",
     "sinon": "^6.1.4",
     "standard": "^11.0.1"
+  },
+  "dependencies": {
+    "keycode": "^2.2.0"
   }
 }


### PR DESCRIPTION
## Context

`keycode` is needed for the library to work; attempting to use this library will give users the following error:

```
node_modules/key-controller/lib/controller.js:5:20: Cannot resolve dependency 'keycode'
```

## Objective

* Add `keycode` as a dependency, rather than a devDependency

## References

* https://github.com/ScottyFillups/key-controller/issues/6