### PR TITLE
docs(2): Add Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Context
+
+<!-- Why do we need this PR? What was the reason that led you to make this change? -->
+
+## Objective
+
+<!-- What does this PR fix? What intentional changes will this PR make? -->
+
+## References
+
+<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
+
+## Lessons learned
+
+<!-- Note any difficulties you overcome, and how you did it -->


### PR DESCRIPTION
## Context

Github templates enable you to add a default template that users can fill out when making PRs or issues. Adding templates (hopefully) establish a minimal guideline for developers to follow when making contributions.

## Objective

* Add a pull request and issue template

## References

* Issue: https://github.com/ScottyFillups/key-controller/issues/2