### PR TITLE
chore(4): Add CI and automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+cache:
+  directories:
+    - ~/.npm
+notifications:
+  email: false
+node_js:
+  - '10'
+  - '9'
+  - '8'
+  - '6'
+after_success:
+  - npm run travis-deploy-once "npm run semantic-release"
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,13 @@ node_js:
   - '10'
   - '9'
   - '8'
-  - '6'
+sudo: required
+dist: trusty
+addons:
+    chrome: stable
+before_script:
+    - "sudo chown root /opt/google/chrome/chrome-sandbox"
+    - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
 after_success:
   - npm run travis-deploy-once "npm run semantic-release"
 branches:

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "key-controller",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "main": "index.js",
   "repository": "git@github.com:ScottyFillups/key-controller.git",
   "author": "Philip Scott <pscott@zeptohost.com>",
   "license": "MIT",
   "scripts": {
-    "test": "karma start --single-run --browsers ChromeHeadless karma.config.js",
-    "demo": "parcel ./demo/index.html --open"
+    "fix": "standard --fix",
+    "lint": "standard",
+    "test": "yarn run lint && karma start --single-run --browsers ChromeHeadless karma.config.js",
+    "demo": "parcel ./demo/index.html --open",
+    "semantic-release": "semantic-release",
+    "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",
@@ -26,7 +30,9 @@
     "parcel-bundler": "^1.9.6",
     "puppeteer": "^1.6.0",
     "sinon": "^6.1.4",
-    "standard": "^11.0.1"
+    "standard": "^11.0.1",
+    "semantic-release": "^15.8.1",
+    "travis-deploy-once": "^5.0.1"
   },
   "dependencies": {
     "keycode": "^2.2.0"


### PR DESCRIPTION
## Context

Travis-CI should run tests against PRs automatically. If all tests pass, the changes should be published to NPM.

## Objective

* Add `.travis.yml`
* Lint code in `test` script
* Add `semantic-release` publishing

## References

Issues:
* https://github.com/ScottyFillups/key-controller/issues/4
* https://github.com/ScottyFillups/key-controller/issues/12

## Lessons learned

Use [semantic-release-cli](https://github.com/semantic-release/cli)