### PR TITLE
feat(14): Bind multiple keys to virtual key

### DIFF
--- a/lib/invert.js
+++ b/lib/invert.js
@@ -2,6 +2,7 @@
 
 /**
  * Swaps JSON values with keys; assumes JSON is a bijection
+ * Array values are destructured as keys in the inverted JSON
  * @func    invert
  * @param   {Object} json  JSON to invert
  * @throws  {type}         The duplicate value if the JSON is not a bijection
@@ -14,7 +15,13 @@ function invert (json) {
     if (swapped[json[key]]) {
       throw json[key]
     } else {
-      swapped[json[key]] = key
+      if (Array.isArray(json[key])) {
+        json[key].forEach((value) => {
+          swapped[value] = key
+        })
+      } else {
+        swapped[json[key]] = key
+      }
     }
   }
 

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -68,13 +68,19 @@ describe('controller maps commands to keyboard codes', () => {
         keydown (model) {
           model.a = 'keydown reset'
         }
+      },
+      multi: {
+        keydown (model) {
+          model.a = 'keydown multi'
+        }
       }
     }
     controls = {
       inc: 'w',
       dec: 'a',
       reset: 's',
-      caps: 'A'
+      caps: 'A',
+      multi: ['H', 'g', 'G']
     }
 
     controller = new Controller(myModel, virtuals)
@@ -93,7 +99,7 @@ describe('controller maps commands to keyboard codes', () => {
   })
 
   describe('headless chrome DOM', () => {
-    it('should be able to register an event and call the handler', () => {
+    it('registers an event and call the handler', () => {
       let model = 0
       const handler = () => {
         model = 1
@@ -107,7 +113,7 @@ describe('controller maps commands to keyboard codes', () => {
     })
   })
 
-  it('should register events using document.addEventListener', () => {
+  it('registers events using document.addEventListener', () => {
     const documentDispatchSpy = sinon.spy(document, 'dispatchEvent')
 
     expect(documentAddEventSpy.calledWith('keyup', controller._handlers['keyup']))
@@ -124,7 +130,7 @@ describe('controller maps commands to keyboard codes', () => {
     expect(myModel.a).to.equal('keydown inc')
   })
 
-  it('should call the appropriate handler', () => {
+  it('calls the appropriate handler', () => {
     keyupPress('w')
     expect(myModel.a).to.equal('keyup inc')
 
@@ -144,7 +150,27 @@ describe('controller maps commands to keyboard codes', () => {
     expect(myModel.a).to.equal('keydown caps')
   })
 
-  it('should call the wildcard handler when any key is pressed', () => {
+  it('handles multiple keys binded to a single virtual key', () => {
+    keyupPress('w')
+    expect(myModel.a).to.equal('keyup inc')
+
+    keydownPress('H')
+    expect(myModel.a).to.equal('keydown multi')
+
+    keydownPress('w')
+    expect(myModel.a).to.equal('keydown inc')
+
+    keydownPress('G')
+    expect(myModel.a).to.equal('keydown multi')
+
+    keydownPress('s')
+    expect(myModel.a).to.equal('keydown reset')
+
+    keydownPress('g')
+    expect(myModel.a).to.equal('keydown multi')
+  })
+
+  it('calls the wildcard handler when any key is pressed', () => {
     expect(myModel.calls).to.equal(0)
 
     keydownPress('n')
@@ -163,7 +189,7 @@ describe('controller maps commands to keyboard codes', () => {
     expect(myModel.calls).to.equal(5)
   })
 
-  it('should overwrite old controls when passed new controls', () => {
+  it('overwrites old controls when passed new controls', () => {
     removeEvents()
 
     controller.register({
@@ -205,7 +231,7 @@ describe('controller maps commands to keyboard codes', () => {
     expect(myModel.a).to.equal('keydown reset')
   })
 
-  it('should be able to bind and unbind the controller', () => {
+  it('bind and unbind the controller', () => {
     controller.unbind()
     removeEvents()
     keyupPress('w')

--- a/test/invert.test.js
+++ b/test/invert.test.js
@@ -47,4 +47,33 @@ describe('invert.js inverts an object\'s keys and values', () => {
       expect(dup).to.equal('3')
     }
   })
+
+  it('destructures array values into keys in inverted object', () => {
+    const obj = {
+      'foo': ['bar', 'baz'],
+      'a': '1',
+      'b': '2'
+    }
+    const inverse = invert(obj)
+
+    expect(inverse).to.deep.equal({
+      'bar': 'foo',
+      'baz': 'foo',
+      '1': 'a',
+      '2': 'b'
+    })
+  })
+
+  it('throws duplicate object when array values appear multiple times', () => {
+    const obj = {
+      'foo': ['bar', 'baz'],
+      'a': ['ayy', 'bar'],
+      'b': '2'
+    }
+    try {
+      invert(obj)
+    } catch (dup) {
+      expect(dup).to.equal('bar')
+    }
+  })
 })


### PR DESCRIPTION
## Context

Users may want alternative key bindings for a single virtual key. One example is supporting both WASD and the arrow keys simultaneously:

```js
const controls = {
  left: ['ArrowLeft', 'a'],
  right: ['ArrowRight', 'd'],
  up: ['ArrowUp', 'w'],
  down: ['ArrowDown', 's']
}
```

## Objective

* Allows users to bind multiple keys to a virtual key

## References

* Issue: https://github.com/ScottyFillups/key-controller/issues/14