### PR TITLE
 feat(15): Add support compound keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 key-controller is a library that simplifies registering handlers for `keydown` and `keyup` events.
 
+key-controller currently only supports projects that transpile ES6. We plan to make a UMD build soon :smiley:
+
+key-controller uses [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) for mapping controls to virtual keys.
+
 ## Installation
 
 ```
@@ -18,14 +22,15 @@ npm install key-controller --save-dev
 import Controller from 'key-controller'
 
 const myModel = {
-  num: 0
+  num: 0,
+  x: 0,
+  y: 0,
+  isDancing: false
 }
 const virtuals = {
   inc: {
-    keydown (model, e) { // e is the Keyboard Event; you can manually check if the shift key is pressed
-      if (e.shiftKey) {  // In this case, we're checking if '+' is pressed, not '='
-        model.num += 1
-      }
+    keydown (model) {
+      model.num += 1
     }
   },
   dec: {
@@ -33,15 +38,47 @@ const virtuals = {
       model.num -= 1
     }
   },
-  _: { // the "_" virtual key is special; it's triggered by any keypress and is used primarily for debugging
+  moveLeft: {
+    keydown (model) {
+      model.x -= 1
+    }
+  },
+  moveRight: {
+    keydown (model) {
+      model.x += 1
+    }
+  },
+  moveUp: {
+    keydown (model) {
+      model.y += 1
+    }
+  },
+  moveDown: {
+    keydown (model) {
+      model.y -= 1
+    }
+  },
+  toggleDancing: {
+    keydown (model) {
+      model.isDancing = !model.isDancing
+    }
+  },
+  // the "_" virtual key is special;
+  // it's triggered by any keypress and is used primarily for debugging
+  _: { 
     keydown (model) {
       console.log(model)
     }
   }
 }
 const controls = {
-  inc: '=', // at the moment, key-controller does not support case-sensitive keys; must ae lower-case
-  dec: '-'
+  inc: '+',
+  dec: '-',
+  moveLeft: ['ArrowLeft', 'a'],
+  moveRight: ['ArrowRight', 'd'],
+  moveUp: ['ArrowUp', 'w'],
+  moveDown: ['ArrowDown', 's'],
+  toggleDance: 'alt+d'
 }
 const controller = new Controller(myModel, virtuals)
 
@@ -50,7 +87,3 @@ controller.register(controls) // map keyboard controls to "virtual keys"
 // controller.register( ... ) can be called with new controls any time;
 // this overwrites the old controls
 ```
-
-key-controller currently only supports projects that transpile ES6. We plan to make a UMD build soon :smiley:
-
-key-controller uses [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) for mapping controls to virtual keys.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const virtuals = {
       model.y -= 1
     }
   },
-  toggleDancing: {
+  toggleDance: {
     keydown (model) {
       model.isDancing = !model.isDancing
     }

--- a/demo/entry.js
+++ b/demo/entry.js
@@ -2,12 +2,20 @@ import Controller from '../lib'
 import * as virtuals from './virtuals'
 
 const model = {
-  num: 0
+  num: 0,
+  rage: false,
+  x: 0,
+  y: 0
 }
 const controls = {
   inc: '1',
   dec: '2',
-  reset: '3'
+  reset: '3',
+  left: ['ArrowLeft', 'a'],
+  up: ['ArrowUp', 'w'],
+  down: ['ArrowDown', 's'],
+  right: ['ArrowRight', 'd'],
+  special: 'ctrl+alt+*'
 }
 
 const controller = new Controller(model, virtuals)

--- a/demo/virtuals.js
+++ b/demo/virtuals.js
@@ -18,10 +18,40 @@ const _ = {
     console.log(model)
   }
 }
+const left = {
+  keydown (model) {
+    model.x -= 1
+  }
+}
+const right = {
+  keydown (model) {
+    model.x += 1
+  }
+}
+const up = {
+  keydown (model) {
+    model.y += 1
+  }
+}
+const down = {
+  keydown (model) {
+    model.y -= 1
+  }
+}
+const special = {
+  keydown (model) {
+    model.rage = !model.rage
+  }
+}
 
 export {
   inc,
   dec,
   reset,
+  left,
+  right,
+  up,
+  down,
+  special,
   _
 }

--- a/lib/compound.js
+++ b/lib/compound.js
@@ -13,7 +13,9 @@ function desensitize (keystring) {
     return keystring
   }
   if (keystring.split('').pop() === '+') {
-    keys.pop().pop().push('+')
+    keys.pop()
+    keys.pop()
+    keys.push('+')
   }
 
   const primaryKey = keys.pop()

--- a/lib/compound.js
+++ b/lib/compound.js
@@ -1,0 +1,53 @@
+'use strict'
+
+/**
+ * Normalizes the case and ordering of compound keys
+ * @func    desensitize
+ * @param   {string} keystring  The compound key to normalize
+ * @returns {string}            The normalized compound key
+ */
+function desensitize (keystring) {
+  const keys = keystring.split('+')
+
+  if (keystring === '+') {
+    return keystring
+  }
+  if (keystring.split('').pop() === '+') {
+    keys.pop().pop().push('+')
+  }
+
+  const primaryKey = keys.pop()
+  const keyArray = keys.map(str => str.toLowerCase()).sort()
+
+  keyArray.push(primaryKey)
+
+  return keyArray.join('+')
+}
+
+/**
+ * Decorates KeyboardEvent.key to reflect whether Alt, Ctrl, or Meta
+ * has been pressed. Shift is ignored, since e.key already accounts for it
+ * @func    decorate
+ * @param   {Object} event  A KeyboardEvent
+ * @returns {string}        KeyboardEvent.key, decorated to reflect if peripheral keys were held
+ */
+function decorate (event) {
+  let modifiers = ''
+
+  if (event.altKey) {
+    modifiers += 'alt+'
+  }
+  if (event.ctrlKey) {
+    modifiers += 'ctrl+'
+  }
+  if (event.metaKey) {
+    modifiers += 'meta+'
+  }
+
+  return modifiers + event.key
+}
+
+export {
+  desensitize,
+  decorate
+}

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -2,6 +2,7 @@
 
 import invert from './invert'
 import rotate from './rotate'
+import { decorate, desensitize } from './compound'
 
 class Controller {
   /**
@@ -23,8 +24,15 @@ class Controller {
     const virtualsByEvent = rotate(this._virtuals)
     let keymap
 
+    for (const virtual in controls) {
+      if (Array.isArray(controls[virtual])) {
+        controls[virtual] = controls[virtual].map(desensitize)
+      } else {
+        controls[virtual] = desensitize(controls[virtual])
+      }
+    }
+
     try {
-      // keymap should store case-insensitive compound keys
       keymap = invert(controls)
     } catch (err) {
       throw new Error(`Cannot register controls; attempting to bind ${err} to multiple virtual keys`)
@@ -32,8 +40,7 @@ class Controller {
 
     for (const event in virtualsByEvent) {
       const handler = (e) => {
-        // make a decorator funct for e.key, like getKey(e)
-        const fn = virtualsByEvent[event][keymap[e.key]]
+        const fn = virtualsByEvent[event][keymap[decorate(e)]]
         const wildcardFn = virtualsByEvent[event]['_']
 
         if (fn) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -24,6 +24,7 @@ class Controller {
     let keymap
 
     try {
+      // keymap should store case-insensitive compound keys
       keymap = invert(controls)
     } catch (err) {
       throw new Error(`Cannot register controls; attempting to bind ${err} to multiple virtual keys`)
@@ -31,6 +32,7 @@ class Controller {
 
     for (const event in virtualsByEvent) {
       const handler = (e) => {
+        // make a decorator funct for e.key, like getKey(e)
         const fn = virtualsByEvent[event][keymap[e.key]]
         const wildcardFn = virtualsByEvent[event]['_']
 

--- a/test/compound.test.js
+++ b/test/compound.test.js
@@ -1,0 +1,57 @@
+/* global describe, it, KeyboardEvent */
+
+'use strict'
+
+import { decorate, desensitize } from '../lib/compound'
+import { expect } from 'chai'
+
+describe('Compound library handles compound keys', () => {
+  describe('decorate decorates KeyboardEvent.key', () => {
+    it('prepends peripheral active keys, in alphabetical order', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'A',
+        ctrlKey: true,
+        altKey: true,
+        metaKey: true
+      })
+
+      expect(decorate(event)).to.equal('alt+ctrl+meta+A')
+    })
+
+    it('does not account for the shift key', () => {
+      const event = new KeyboardEvent('keydown', {
+        key: '+',
+        ctrlKey: true,
+        altKey: true,
+        shiftKey: true
+      })
+
+      expect(decorate(event)).to.equal('alt+ctrl++')
+    })
+  })
+
+  describe('desensitize normalizes case and ordering of compound keys', () => {
+    it('normalizes case, calling toLowerCase()', () => {
+      expect(desensitize('ALT+CTRL+p')).to.equal('alt+ctrl+p')
+      expect(desensitize('Ctrl+Meta+ArrowLeft')).to.equal('ctrl+meta+ArrowLeft')
+    })
+
+    it('ensures the peripheral keys are in alphabetical order', () => {
+      expect(desensitize('ctrl+meta+alt+p')).to.equal('alt+ctrl+meta+p')
+      expect(desensitize('meta+ctrl+2')).to.equal('ctrl+meta+2')
+    })
+
+    it('does not modify primitive keys', () => {
+      expect(desensitize('A')).to.equal('A')
+      expect(desensitize('Space')).to.equal('Space')
+      expect(desensitize('ArrowLeft')).to.equal('ArrowLeft')
+      expect(desensitize('+')).to.equal('+')
+    })
+
+    it('normalizes both case and ordering simultaneously', () => {
+      expect(desensitize('cTRl+META+alt+p')).to.equal('alt+ctrl+meta+p')
+      expect(desensitize('ctrl+aLT+Space')).to.equal('alt+ctrl+Space')
+      expect(desensitize('meta+Ctrl+2')).to.equal('ctrl+meta+2')
+    })
+  })
+})

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -6,7 +6,13 @@ import Controller from '../lib/controller'
 import chai, { expect } from 'chai'
 import dirtyChai from 'dirty-chai'
 import sinon from 'sinon'
-import { keydownPress, keyupPress, keyupShiftPress } from './keypress'
+import {
+  keydownPress,
+  keyupPress,
+  keydownAltPress,
+  keydownAltCtrlPress,
+  keyupShiftPress
+} from './keypress'
 
 chai.use(dirtyChai)
 
@@ -78,6 +84,11 @@ describe('controller maps commands to keyboard codes', () => {
         keydown (model) {
           model.a = 'keydown multi'
         }
+      },
+      multimod: {
+        keydown (model) {
+          model.a = 'keydown multimod'
+        }
       }
     }
     controls = {
@@ -86,7 +97,8 @@ describe('controller maps commands to keyboard codes', () => {
       reset: 's',
       caps: 'A',
       mod: 'ctrl+alt++',
-      multi: ['H', 'g', 'G']
+      multi: ['H', 'g', 'G'],
+      multimod: ['ctrl+alt+G', 'alt+#']
     }
 
     controller = new Controller(myModel, virtuals)
@@ -174,6 +186,25 @@ describe('controller maps commands to keyboard codes', () => {
 
     keydownPress('g')
     expect(myModel.a).to.equal('keydown multi')
+  })
+
+  it('handles keys with modifiers', () => {
+    keydownAltCtrlPress('+')
+    expect(myModel.a).to.equal('keydown ctrl+alt++')
+  })
+
+  it('handles multiple keys, with modifiers, binded to a single virtual key', () => {
+    keyupPress('w')
+    expect(myModel.a).to.equal('keyup inc')
+
+    keydownAltPress('#')
+    expect(myModel.a).to.equal('keydown multimod')
+
+    keydownPress('w')
+    expect(myModel.a).to.equal('keydown inc')
+
+    keydownAltCtrlPress('G')
+    expect(myModel.a).to.equal('keydown multimod')
   })
 
   it('calls the wildcard handler when any key is pressed', () => {

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -68,13 +68,19 @@ describe('controller maps commands to keyboard codes', () => {
         keydown (model) {
           model.a = 'keydown reset'
         }
+      },
+      mod: {
+        keydown (model) {
+          model.a = 'keydown ctrl+alt++'
+        }
       }
     }
     controls = {
       inc: 'w',
       dec: 'a',
       reset: 's',
-      caps: 'A'
+      caps: 'A',
+      mod: 'ctrl+alt++'
     }
 
     controller = new Controller(myModel, virtuals)

--- a/test/keypress.js
+++ b/test/keypress.js
@@ -21,7 +21,20 @@ function keyupShiftPress (key) {
   keyPress(key, 'keyup', { shiftKey: true })
 }
 
+function keydownAltCtrlPress (key) {
+  keyPress(key, 'keydown', {
+    ctrlKey: true,
+    altKey: true
+  })
+}
+
+function keydownAltPress (key) {
+  keyPress(key, 'keydown', { altKey: true })
+}
+
 export {
+  keydownAltCtrlPress,
+  keydownAltPress,
   keyupShiftPress,
   keydownPress,
   keyupPress


### PR DESCRIPTION
## Context

Users should be able to bind compound keybindings, eg:

```js
const controls = {
  foo: 'alt+ctrl+b'
}
```

The ordering of the modifiers, and the case, should not matter.

## Objective

* Add support for compound keybindings

## References

* Issue: https://github.com/ScottyFillups/key-controller/issues/15