### PR TITLE
fix(19): Fix bind() for controller

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -72,7 +72,7 @@ class Controller {
    */
   bind () {
     for (const event in this._virtuals) {
-      document.body.removeEventListener(event, this._handlers[event])
+      document.body.addEventListener(event, this._handlers[event])
     }
   }
 }

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -284,6 +284,8 @@ describe('controller maps commands to keyboard codes', () => {
     expect(myModel.a).to.equal('keydown reset')
   })
 
+  // Note: this test actually test bind(); all the work is being done by
+  // removeEvents() and addEvents() - this is acting as a placeholder once a better workaround has been found
   it('bind and unbind the controller', () => {
     controller.unbind()
     removeEvents()


### PR DESCRIPTION
## Context

`bind()` is calling `removeEventListener` rather than `addEventListener`

## Objective

* Fix `bind()`

## References

Issue: https://github.com/ScottyFillups/key-controller/issues/19