### PR TITLE
fix: Include UMD in NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 demo/
-umd/
 test/
 .travis.yml


### PR DESCRIPTION
## Context

Since `umd/` is ignored, it's not included in the NPM package, so unpkg.com cannot find it.

## Objective

* Un-ignore `umd/` so the instructions in the installation guide are correct